### PR TITLE
Remove nonexistent data app from root URLs

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -8,7 +8,6 @@ from django.urls import include, path
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("", include("apps.data.urls", namespace="data")),
     path("auth/", include("apps.custom_user.urls", namespace="custom_user")),
     # Example for your apps:
     # path('dashboard/', include('apps.dashboard.urls')),


### PR DESCRIPTION
## Summary
- remove reference to `apps.data` from root URL configuration

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements/dev.in` *(fails: Could not find a version that satisfies the requirement Django<5.0,>=4.2; Cannot connect to proxy)*
- `pre-commit run --files config/urls.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68947b61c26c832695bed2098597083f