### PR TITLE
Add environment templates and default envfile for secret target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ env/
 .env
 .envrc
 environments/*.env
+!environments/base.env
+!environments/dev.env
 
 # SQLite database (used for dev/testing)
 *.sqlite3

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SHELL := /bin/bash
 
 # Default environment
 ENV ?= dev
+envfile ?= environments/dev.env
 PYTHON := $(shell [ -f ".venv/bin/python" ] && echo ".venv/bin/python" || echo ".venv/Scripts/python")
 
 .PHONY: runserver makemigrations migrate shell setup compile venv deps format lint test test-fast commit push feature release secret superuser smoke
@@ -45,18 +46,15 @@ venv:
 
 # Generate a new Django SECRET_KEY and append it to the env file
 secret:
-	@if [ -z "$(envfile)" ]; then \
-		echo "❌ Please specify envfile: make secret envfile=environments/.dev"; \
-		exit 1; \
-	fi
-	@echo "🔑 Generating Django SECRET_KEY..."
-	SECRET_KEY=$$($(PYTHON) -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"); \
-	if grep -q '^SECRET_KEY=' $(envfile); then \
-		sed -i'' -e "s/^SECRET_KEY=.*/SECRET_KEY=$$SECRET_KEY/" $(envfile); \
-	else \
-		echo "SECRET_KEY=$$SECRET_KEY" >> $(envfile); \
-	fi
-	@echo "✅ SECRET_KEY updated in $(envfile)"
+@echo "🔑 Generating Django SECRET_KEY..."
+@touch $(envfile)
+SECRET_KEY=$$($(PYTHON) -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"); \
+if grep -q '^SECRET_KEY=' $(envfile); then \
+sed -i'' -e "s/^SECRET_KEY=.*/SECRET_KEY=$$SECRET_KEY/" $(envfile); \
+else \
+echo "SECRET_KEY=$$SECRET_KEY" >> $(envfile); \
+fi
+@echo "✅ SECRET_KEY updated in $(envfile)"
 
 # Create superuser
 superuser:

--- a/environments/base.env
+++ b/environments/base.env
@@ -1,0 +1,3 @@
+DEBUG=False
+SECRET_KEY=changeme
+ALLOWED_HOSTS=localhost

--- a/environments/dev.env
+++ b/environments/dev.env
@@ -1,0 +1,6 @@
+# Inherit from base.env
+set -a
+. "$(dirname "${BASH_SOURCE[0]:-$0}")/base.env"
+set +a
+
+DEBUG=True


### PR DESCRIPTION
## Summary
- add base and dev environment templates
- ensure environment templates are tracked while ignoring other env files
- default Makefile secret target to environments/dev.env

## Testing
- `pre-commit run --files .gitignore Makefile environments/base.env environments/dev.env` *(fails: command not found)*
- `pip install pre-commit pytest django pytest-django` *(fails: Could not connect to proxy)*
- `pytest apps/tests/test_urls.py -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68947c6e124083269a1f33655f2fa2c6