### PR TITLE
Refactor JWT login to use Django authenticate

### DIFF
--- a/apps/custom_user/views.py
+++ b/apps/custom_user/views.py
@@ -1,4 +1,4 @@
-from django.contrib.auth import get_user_model
+from django.contrib.auth import authenticate, get_user_model
 from rest_framework import generics, permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -50,14 +50,8 @@ class ObtainJWTTokenView(APIView):
         email = request.data.get("email")
         password = request.data.get("password")
 
-        try:
-            user = User.objects.get(email=email)
-        except User.DoesNotExist:
-            return Response(
-                {"detail": "Invalid credentials"}, status=status.HTTP_401_UNAUTHORIZED
-            )
-
-        if not user.check_password(password):
+        user = authenticate(request, email=email, password=password)
+        if user is None:
             return Response(
                 {"detail": "Invalid credentials"}, status=status.HTTP_401_UNAUTHORIZED
             )


### PR DESCRIPTION
## Summary
- use `django.contrib.auth.authenticate` instead of manual lookup in JWT token view

## Testing
- `pytest apps/custom_user/tests.py -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `pre-commit run --files apps/custom_user/views.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68947ea102b48326aaff2e86b633c181