### PR TITLE
docs: add project structure section

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ settings, and built-in authentication.
 
 ---
 
+## Project Structure
+
+- `apps/` — project apps including the custom user app
+- `config/settings/` — modular Django settings
+- `docs/` — project documentation and guides
+- `environments/` — sample environment variable files
+- `requirements/` — Python dependency specifications
+- `templates/` — HTML templates
+
+---
+
 ## Quick Start
 
 1. **Create your environment**


### PR DESCRIPTION
## Summary
- document key directories in a new Project Structure section

## Testing
- `pre-commit run --files README.md` *(failed: command not found)*
- `pip install pre-commit` *(failed: No matching distribution found due to proxy 403)*
- `make lint` *(failed: missing separator in Makefile)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6894822252d08326942ebd9ecf8a874c